### PR TITLE
Feature/go io reader writer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ FetchContent_MakeAvailable(googletest)
 
 if("$ENV{BUILD_MODE}" STREQUAL "web")
 add_compile_options(-fexperimental-library)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexceptions -sENVIRONMENT=worker,node -sINVOKE_RUN=0 -sMODULARIZE=1 -sEXPORT_ES6=1 -sEXIT_RUNTIME=0 -sEXPORTED_RUNTIME_METHODS=[ccall,cwrap,FS] -sALLOW_MEMORY_GROWTH=1")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexceptions -sENVIRONMENT=worker -sINVOKE_RUN=0 -sMODULARIZE=1 -sEXPORT_ES6=1 -sEXIT_RUNTIME=0 -sEXPORTED_RUNTIME_METHODS=[ccall,cwrap,FS] -sALLOW_MEMORY_GROWTH=1")
 endif()
 
 # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pg -mfentry")

--- a/src/ebmcg/ebm2go/visitor/Flags.hpp
+++ b/src/ebmcg/ebm2go/visitor/Flags.hpp
@@ -26,5 +26,6 @@
 
 FILE_EXTENSIONS(".go");
 WEB_UI_NAME("go3");
+DEFINE_BOOL_FLAG(use_bytes_slice, false, "use-io-reader-writer", "Use bytes slice instead of io.Reader/io.Writer for encoder/decoder input/output");
 DEFINE_STRING_FLAG(package_name, "", "package", "Package name for generated Go code", "NAME");
 CONFIG_MAP("config.go.package", package_name);

--- a/src/ebmcg/ebm2go/visitor/Visitor_before.hpp
+++ b/src/ebmcg/ebm2go/visitor/Visitor_before.hpp
@@ -16,3 +16,4 @@ std::unordered_set<std::uint64_t> bool_mapped_func;
 std::unordered_map<std::uint64_t, ArrayLengthInfo> array_length_setters;
 std::unordered_set<std::uint64_t> array_length_set_done;
 bool inner_prop_setter = false;
+bool use_io_reader_writer = true;

--- a/src/ebmcodegen/stub/entry.hpp
+++ b/src/ebmcodegen/stub/entry.hpp
@@ -31,6 +31,7 @@ namespace ebmcodegen {
         bool dump_code = false;
         bool show_flags = false;
         bool timing = false;
+        bool source_map = false;
         Timepoint start{};
         Timepoint prev{};
         // std::vector<std::string_view> args;
@@ -79,6 +80,17 @@ namespace ebmcodegen {
             ctx.VarString<true>(&dump_test_separator, "test-separator", "dump test info separator when dumping test info to stdout", "SEP");
             ctx.VarBool(&debug_unimplemented, "debug-unimplemented", "debug unimplemented node (for debug)");
             ctx.VarBool(&timing, "timing", "show timing info (for debug)");
+            ctx.VarBoolFunc(&source_map, "source-map", "same as --test-info - --test-separator \"############\" (for WebPlayground compatibility)", [&](bool flag, auto) {
+                if (flag) {
+                    dump_test_file = "-";
+                    dump_test_separator = "############";
+                }
+                else {
+                    dump_test_file = "";
+                    dump_test_separator = "";
+                }
+                return true;
+            });
             web_filtered = {"help", "input", "output", "show-flags", "dump-code", "test-info", "test-separator", "timing"};
         }
     };


### PR DESCRIPTION
This pull request introduces a new configurable mode for Go code generation, allowing the encoder and decoder IO to use either `io.Reader`/`io.Writer` or `*[]byte` (slice) types. The default is now `io.Reader`/`io.Writer`, but users can switch back to the previous slice mode via a flag. The changes update the test harness, code generation logic, and add a new flag for user control. Additionally, there are minor improvements to command-line flag handling and web compatibility.

**Go Code Generation Modes**

* Added a new flag (`use_bytes_slice`) to control whether generated Go code uses `io.Reader`/`io.Writer` or `*[]byte` for encoder/decoder IO; default is now `io.Reader`/`io.Writer`. [[1]](diffhunk://#diff-b40c512b3c6158190c6dd6a60d4a981bd2a79ccc97d28a5ba415d97fd049bc13R29) [[2]](diffhunk://#diff-57921af9d89b05d8b974f63429628d0a10ba5ab0a136310135b3f59d5d7e446aL89-R95) [[3]](diffhunk://#diff-57921af9d89b05d8b974f63429628d0a10ba5ab0a136310135b3f59d5d7e446aR119-R127) [[4]](diffhunk://#diff-3b639b656f6927f62056af59f0e8820dd062d0b19e400cf6e484153c5dd4072fR19)
* Updated code generation logic in visitors to support both modes, including handling of arrays, vectors, and byte ranges for reading and writing operations. [[1]](diffhunk://#diff-45c6ce23fea1bc58872087c3c29e8e210f626748e078dd8f063e14590b00da01R61-R90) [[2]](diffhunk://#diff-b883b0a937e6027b192a57bbbdaea6111ce9d35b192b116663a68ad55fe9dbd0R102-R124) [[3]](diffhunk://#diff-39a5e5571868c2d9e22905c6b782ce9b60b18e2d79dd48df5a4d7339f8eec5edR41-R72) [[4]](diffhunk://#diff-57921af9d89b05d8b974f63429628d0a10ba5ab0a136310135b3f59d5d7e446aR243-R247) [[5]](diffhunk://#diff-57921af9d89b05d8b974f63429628d0a10ba5ab0a136310135b3f59d5d7e446aR259) [[6]](diffhunk://#diff-57921af9d89b05d8b974f63429628d0a10ba5ab0a136310135b3f59d5d7e446aR384-R388)

**Test Harness Update**

* Modified the generated Go test harness in `main.go` to use `io.Reader`/`io.Writer` for decoder/encoder IO, wrapping input data with `bytes.NewReader` and using `bytes.Buffer` for output. [[1]](diffhunk://#diff-1eab7860105727b07be6734ba5c736b2d6233508a173ffcd0f592f9f071fee16L33-R44) [[2]](diffhunk://#diff-1eab7860105727b07be6734ba5c736b2d6233508a173ffcd0f592f9f071fee16L67-R83)

**Command-Line Flags and Web Compatibility**

* Added a new `source-map` flag for web playground compatibility, which sets test output and separator options. [[1]](diffhunk://#diff-a5296bf2f0ba18a6db0b8ada9723bda091ff9c843205a1fc02580df3df188663R34) [[2]](diffhunk://#diff-a5296bf2f0ba18a6db0b8ada9723bda091ff9c843205a1fc02580df3df188663R83-R93)

**Build Configuration**

* Adjusted the CMake build flags for web mode to remove the `node` environment, focusing only on `worker`.